### PR TITLE
fix: address security vulnerabilities in API routes

### DIFF
--- a/src/app/api/admin/fix-order-reference/route.ts
+++ b/src/app/api/admin/fix-order-reference/route.ts
@@ -22,13 +22,14 @@ type OrderItemRef = {
 
 export async function POST(req: NextRequest) {
     try {
-        // Simple auth: require Authorization: Bearer <ADMIN_API_SECRET>
-        if (ADMIN_SECRET) {
-            const bearer = req.headers.get('authorization');
-            const token = bearer?.split(' ')?.[1];
-            if (token !== ADMIN_SECRET) {
-                return NextResponse.json({ message: 'Unauthorized' }, { status: 401 });
-            }
+        // Require Authorization: Bearer <ADMIN_API_SECRET>
+        if (!ADMIN_SECRET) {
+            return NextResponse.json({ message: 'Admin API secret not configured' }, { status: 503 });
+        }
+        const bearer = req.headers.get('authorization');
+        const token = bearer?.split(' ')?.[1];
+        if (token !== ADMIN_SECRET) {
+            return NextResponse.json({ message: 'Unauthorized' }, { status: 401 });
         }
 
         // Parse JSON body if provided; otherwise fall back to query params
@@ -148,13 +149,14 @@ export async function POST(req: NextRequest) {
 
 export async function GET(req: NextRequest) {
     try {
-        // Simple auth (optional) via ADMIN_API_SECRET on GET too
-        if (ADMIN_SECRET) {
-            const bearer = req.headers.get('authorization');
-            const token = bearer?.split(' ')?.[1];
-            if (token !== ADMIN_SECRET) {
-                return NextResponse.json({ message: 'Unauthorized' }, { status: 401 });
-            }
+        // Require Authorization: Bearer <ADMIN_API_SECRET>
+        if (!ADMIN_SECRET) {
+            return NextResponse.json({ message: 'Admin API secret not configured' }, { status: 503 });
+        }
+        const bearer = req.headers.get('authorization');
+        const token = bearer?.split(' ')?.[1];
+        if (token !== ADMIN_SECRET) {
+            return NextResponse.json({ message: 'Unauthorized' }, { status: 401 });
         }
 
         const qp = req.nextUrl?.searchParams;

--- a/src/app/api/email-preview/tracking/route.ts
+++ b/src/app/api/email-preview/tracking/route.ts
@@ -1,12 +1,22 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+function escapeHtml(str: string): string {
+	return str
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;')
+		.replace(/"/g, '&quot;')
+		.replace(/'/g, '&#x27;');
+}
+
 export async function GET(req: NextRequest) {
 	const { searchParams } = new URL(req.url);
-	const productsText = searchParams.get('productsText') || 'Espresso Blend (Qty: 1), Ethiopia Guji (Qty: 2)';
-	const trackingNumber = searchParams.get('trackingNumber') || '9400 0000 0000 0000 0000 00';
-	const firstName = searchParams.get('firstName') || 'there';
+	const rawTrackingNumber = searchParams.get('trackingNumber') || '9400 0000 0000 0000 0000 00';
+	const productsText = escapeHtml(searchParams.get('productsText') || 'Espresso Blend (Qty: 1), Ethiopia Guji (Qty: 2)');
+	const trackingNumber = escapeHtml(rawTrackingNumber);
+	const firstName = escapeHtml(searchParams.get('firstName') || 'there');
 	const uspsTrackingUrl = `https://tools.usps.com/go/TrackConfirmAction?tLabels=${encodeURIComponent(
-		trackingNumber
+		rawTrackingNumber
 	)}`;
 
 	const html = `

--- a/src/app/api/order-details/route.ts
+++ b/src/app/api/order-details/route.ts
@@ -32,6 +32,10 @@ export async function GET(request: NextRequest) {
 			return NextResponse.json({ error: 'Session not found' }, { status: 404 });
 		}
 
+		if (session.payment_status !== 'paid') {
+			return NextResponse.json({ error: 'Order not found' }, { status: 404 });
+		}
+
 		// Extract relevant information
 		const lineItems = session.line_items?.data.map((item) => {
 			// Type guard to ensure price.product is a Stripe.Product

--- a/src/app/api/send-tracking-email/route.ts
+++ b/src/app/api/send-tracking-email/route.ts
@@ -41,19 +41,15 @@ const SANITY_WEBHOOK_SECRET = process.env.SANITY_WEBHOOK_SECRET;
 
 export async function POST(req: NextRequest) {
 	try {
-		// 1. Verify the webhook signature (if a secret is configured)
-		if (SANITY_WEBHOOK_SECRET) {
-			// Note: Sanity webhook signature verification requires specific header and logic.
-			// For simplicity, this example assumes a basic secret check or relies on network-level security.
-			// A more robust solution would involve crypto.timingSafeEqual for signature comparison.
-			const DUMMY_AUTH_TOKEN_FROM_HEADER = req.headers.get('Authorization')?.split(' ')?.[1];
-			if (DUMMY_AUTH_TOKEN_FROM_HEADER !== SANITY_WEBHOOK_SECRET) {
-				// Replace with actual signature verification
-				console.warn('Unauthorized Sanity webhook attempt');
-				// return NextResponse.json({ message: 'Unauthorized' }, { status: 401 });
-				// For now, we'll log and proceed if the secret is set but doesn't match, for easier local dev
-				// In production, you MUST enforce this.
-			}
+		// 1. Verify the webhook signature
+		if (!SANITY_WEBHOOK_SECRET) {
+			console.error('SANITY_WEBHOOK_SECRET is not configured');
+			return NextResponse.json({ message: 'Webhook secret not configured' }, { status: 503 });
+		}
+		const authToken = req.headers.get('Authorization')?.split(' ')?.[1];
+		if (authToken !== SANITY_WEBHOOK_SECRET) {
+			console.warn('Unauthorized Sanity webhook attempt');
+			return NextResponse.json({ message: 'Unauthorized' }, { status: 401 });
 		}
 
 		const payload = await req.json();


### PR DESCRIPTION
## Summary

- **Critical** — Admin endpoint (`/api/admin/fix-order-reference`) auth is now always enforced. Previously the `if (ADMIN_SECRET)` guard meant the endpoint was completely unprotected if the env var wasn't set. Now returns 503 if unconfigured, 401 on token mismatch.
- **High** — Tracking email webhook (`/api/send-tracking-email`) now rejects unauthorized requests with 401. The rejection was previously commented out, leaving the endpoint open to any caller who could trigger customer emails and write to Sanity.
- **Medium** — Reflected XSS in email preview (`/api/email-preview/tracking`) fixed by HTML-encoding all user-supplied query params (`firstName`, `productsText`, `trackingNumber`) before interpolating into the HTML response.
- **Low** — Order details endpoint (`/api/order-details`) now only returns session data when `payment_status === 'paid'`, preventing data leakage for unpaid or abandoned sessions.

## Test plan

- [ ] Confirm `/api/admin/fix-order-reference` returns 401 without a valid `Authorization: Bearer <ADMIN_API_SECRET>` header
- [ ] Confirm `/api/admin/fix-order-reference` returns 503 if `ADMIN_API_SECRET` env var is unset
- [ ] Confirm `/api/send-tracking-email` returns 401 without a valid `Authorization: Bearer <SANITY_WEBHOOK_SECRET>` header
- [ ] Confirm `/api/email-preview/tracking?firstName=<script>alert(1)</script>` renders escaped text, not executable script
- [ ] Confirm `/api/order-details?session_id=<unpaid_session>` returns 404
- [ ] Confirm checkout success page still loads correctly for a completed payment session

https://claude.ai/code/session_01BziiQ58DFJHRMAdr8exk3M