### PR TITLE
feat: SEO + checkout UX + carry-over security hardening

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -42,6 +42,14 @@ const nextConfig: NextConfig = {
 						key: 'Strict-Transport-Security',
 						value: 'max-age=63072000; includeSubDomains; preload',
 					},
+					{
+						key: 'X-Content-Type-Options',
+						value: 'nosniff',
+					},
+					{
+						key: 'Permissions-Policy',
+						value: 'geolocation=(), microphone=(), camera=()',
+					},
 				],
 			},
 		];

--- a/src/app/about-us/layout.tsx
+++ b/src/app/about-us/layout.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+	title: 'About Us',
+	description:
+		'Discover the story, craft, and people behind Tre Stelle Coffee Co. — bridging modern and traditional coffee craftsmanship in Dallas, TX.',
+	alternates: { canonical: 'https://trestellecoffeeco.com/about-us' },
+	openGraph: {
+		title: 'About Us | Tre Stelle Coffee Co.',
+		description:
+			'Discover the story, craft, and people behind Tre Stelle Coffee Co. — bridging modern and traditional coffee craftsmanship in Dallas, TX.',
+		url: 'https://trestellecoffeeco.com/about-us',
+		type: 'website',
+	},
+};
+
+export default function AboutUsLayout({ children }: { children: React.ReactNode }) {
+	return children;
+}

--- a/src/app/api/checkout/route.ts
+++ b/src/app/api/checkout/route.ts
@@ -122,15 +122,23 @@ export async function POST(req: NextRequest) {
 
 		// Determine shipping based on order total
 		const FREE_SHIPPING_THRESHOLD = 50;
-		const PAID_SHIPPING_RATE_ID = 'shr_1RPxYrChXWBA9KQdMnP9LbP3'; // $5.00 shipping
-		const FREE_SHIPPING_RATE_ID = 'shr_1RPxtPChXWBA9KQdTpNbCZIm'; // Replace with your actual free shipping rate ID from Stripe
+		const PAID_SHIPPING_RATE_ID = process.env.STRIPE_PAID_SHIPPING_RATE_ID || 'shr_1RPxYrChXWBA9KQdMnP9LbP3';
+		const FREE_SHIPPING_RATE_ID = process.env.STRIPE_FREE_SHIPPING_RATE_ID || 'shr_1RPxtPChXWBA9KQdTpNbCZIm';
 
-		const shippingOptions = orderTotal >= FREE_SHIPPING_THRESHOLD 
+		const shippingOptions = orderTotal >= FREE_SHIPPING_THRESHOLD
 			? [{ shipping_rate: FREE_SHIPPING_RATE_ID }]
 			: [{ shipping_rate: PAID_SHIPPING_RATE_ID }];
 
-		// For dynamic origin for success and cancel URLs
-		const origin = req.headers.get('origin') || 'http://localhost:3000';
+		// Validate origin against allowlist to prevent open redirect
+		const ALLOWED_ORIGINS = [
+			'https://trestellecoffeeco.com',
+			'https://www.trestellecoffeeco.com',
+			'http://localhost:3000',
+		];
+		const requestOrigin = req.headers.get('origin') || '';
+		const origin = ALLOWED_ORIGINS.includes(requestOrigin)
+			? requestOrigin
+			: 'https://trestellecoffeeco.com';
 
 		const session = await stripe.checkout.sessions.create({
 			payment_method_types: ['card'],

--- a/src/app/api/submit-review/route.ts
+++ b/src/app/api/submit-review/route.ts
@@ -41,22 +41,56 @@ export async function POST(request: Request) {
 		if (!HCAPTCHA_SECRET) {
 			return NextResponse.json({ message: 'hCaptcha secret not configured.' }, { status: 500 });
 		}
-		const verifyRes = await fetch('https://hcaptcha.com/siteverify', {
-			method: 'POST',
-			headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-			body: `response=${hcaptchaToken}&secret=${HCAPTCHA_SECRET}`,
-		});
-		const verifyData = await verifyRes.json();
+		const captchaController = new AbortController();
+		const captchaTimeout = setTimeout(() => captchaController.abort(), 5000);
+		let verifyData: { success: boolean };
+		try {
+			const verifyRes = await fetch('https://hcaptcha.com/siteverify', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+				body: `response=${hcaptchaToken}&secret=${HCAPTCHA_SECRET}`,
+				signal: captchaController.signal,
+			});
+			verifyData = await verifyRes.json();
+		} catch {
+			return NextResponse.json({ message: 'Captcha verification unavailable. Please try again.' }, { status: 503 });
+		} finally {
+			clearTimeout(captchaTimeout);
+		}
 		if (!verifyData.success) {
 			return NextResponse.json({ message: 'Captcha verification failed.' }, { status: 400 });
 		}
 
-		// Basic validation
+		// Input validation
 		if (!productId || !rating || !comment || !authorName) {
 			return NextResponse.json({ message: 'Missing required fields' }, { status: 400 });
 		}
 		if (typeof rating !== 'number' || rating < 1 || rating > 5) {
 			return NextResponse.json({ message: 'Invalid rating value' }, { status: 400 });
+		}
+		if (typeof authorName !== 'string' || authorName.length > 100) {
+			return NextResponse.json({ message: 'Author name must be 100 characters or less' }, { status: 400 });
+		}
+		if (typeof comment !== 'string' || comment.length > 1000) {
+			return NextResponse.json({ message: 'Comment must be 1000 characters or less' }, { status: 400 });
+		}
+		if (title && (typeof title !== 'string' || title.length > 200)) {
+			return NextResponse.json({ message: 'Title must be 200 characters or less' }, { status: 400 });
+		}
+		if (authorEmail && (typeof authorEmail !== 'string' || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(authorEmail))) {
+			return NextResponse.json({ message: 'Invalid email format' }, { status: 400 });
+		}
+		if (typeof productId !== 'string' || !/^[a-zA-Z0-9._-]+$/.test(productId)) {
+			return NextResponse.json({ message: 'Invalid product ID' }, { status: 400 });
+		}
+
+		// Verify product exists in Sanity before creating review
+		const productExists = await client.fetch<number>(
+			`count(*[_type == "product" && !(_id in path("drafts.**")) && _id == $id])`,
+			{ id: productId }
+		);
+		if (productExists === 0) {
+			return NextResponse.json({ message: 'Product not found' }, { status: 404 });
 		}
 
 		// Create the review document in Sanity

--- a/src/app/api/submit-review/route.ts
+++ b/src/app/api/submit-review/route.ts
@@ -77,8 +77,16 @@ export async function POST(request: Request) {
 		if (title && (typeof title !== 'string' || title.length > 200)) {
 			return NextResponse.json({ message: 'Title must be 200 characters or less' }, { status: 400 });
 		}
-		if (authorEmail && (typeof authorEmail !== 'string' || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(authorEmail))) {
-			return NextResponse.json({ message: 'Invalid email format' }, { status: 400 });
+		if (authorEmail) {
+			if (typeof authorEmail !== 'string') {
+				return NextResponse.json({ message: 'Invalid email format' }, { status: 400 });
+			}
+			const atIdx = authorEmail.indexOf('@');
+			const hasValidAt = atIdx > 0 && atIdx === authorEmail.lastIndexOf('@');
+			const hasDomainDot = hasValidAt && authorEmail.indexOf('.', atIdx + 2) > atIdx + 1;
+			if (!hasValidAt || !hasDomainDot) {
+				return NextResponse.json({ message: 'Invalid email format' }, { status: 400 });
+			}
 		}
 		if (typeof productId !== 'string' || !/^[a-zA-Z0-9._-]+$/.test(productId)) {
 			return NextResponse.json({ message: 'Invalid product ID' }, { status: 400 });
@@ -124,13 +132,6 @@ export async function POST(request: Request) {
 		);
 	} catch (error) {
 		console.error('Error submitting review:', error);
-		let errorMessage = 'An unknown error occurred.';
-		if (error instanceof Error) {
-			errorMessage = error.message;
-		}
-		return NextResponse.json(
-			{ message: 'Failed to submit review', error: errorMessage },
-			{ status: 500 }
-		);
+		return NextResponse.json({ message: 'Failed to submit review' }, { status: 500 });
 	}
 }

--- a/src/app/cart/layout.tsx
+++ b/src/app/cart/layout.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+	title: 'Your Cart',
+	description: 'Review the items in your cart before checking out.',
+	robots: { index: false, follow: false },
+};
+
+export default function CartLayout({ children }: { children: React.ReactNode }) {
+	return children;
+}

--- a/src/app/cart/page.tsx
+++ b/src/app/cart/page.tsx
@@ -285,10 +285,34 @@ export default function CartPage() {
 									<button
 										onClick={handleCheckout}
 										disabled={isLoading || detailedCartItems.length === 0}
-										className="cart-proceed-checkout-button mt-6 block w-full text-center px-6 py-3 bg-primary text-light rounded-md font-semibold text-lg transition-all duration-300 disabled:opacity-50 disabled:cursor-not-allowed border-2 border-primary"
+										aria-busy={isLoading}
+										className="cart-proceed-checkout-button mt-6 flex w-full items-center justify-center gap-2 px-6 py-3 bg-primary text-light rounded-md font-semibold text-lg transition-all duration-300 disabled:opacity-50 disabled:cursor-not-allowed border-2 border-primary"
 									>
-										{isLoading ? 'Processing...' : 'Proceed to Checkout'}
+										{isLoading && (
+											<svg
+												className="animate-spin h-5 w-5 text-light"
+												xmlns="http://www.w3.org/2000/svg"
+												fill="none"
+												viewBox="0 0 24 24"
+												aria-hidden="true"
+											>
+												<circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+												<path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z" />
+											</svg>
+										)}
+										<span>{isLoading ? 'Processing…' : 'Proceed to Checkout'}</span>
 									</button>
+									{isLoading && (
+										<p className="text-xs text-gray-500 mt-2 text-center">
+											Redirecting you to secure checkout…
+										</p>
+									)}
+									<p className="text-xs text-gray-500 mt-2 text-center flex items-center justify-center gap-1">
+										<svg xmlns="http://www.w3.org/2000/svg" className="h-3 w-3" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+											<path fillRule="evenodd" d="M10 1a4.5 4.5 0 00-4.5 4.5V9H5a2 2 0 00-2 2v6a2 2 0 002 2h10a2 2 0 002-2v-6a2 2 0 00-2-2h-.5V5.5A4.5 4.5 0 0010 1zm3 8V5.5a3 3 0 10-6 0V9h6z" clipRule="evenodd" />
+										</svg>
+										Secure checkout powered by Stripe
+									</p>
 									{error && <p className="text-red-500 text-sm mt-2 text-center">{error}</p>}
 								</div>
 							</div>

--- a/src/app/checkout/layout.tsx
+++ b/src/app/checkout/layout.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+	title: 'Checkout',
+	description: 'Complete your Tre Stelle Coffee Co. order.',
+	robots: { index: false, follow: false },
+};
+
+export default function CheckoutLayout({ children }: { children: React.ReactNode }) {
+	return children;
+}

--- a/src/app/events/layout.tsx
+++ b/src/app/events/layout.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+	title: 'Events & Private Bookings',
+	description:
+		'Book Tre Stelle Coffee Co. for private events, coffee experiences, and community gatherings in Dallas, TX.',
+	alternates: { canonical: 'https://trestellecoffeeco.com/events' },
+	openGraph: {
+		title: 'Events & Private Bookings | Tre Stelle Coffee Co.',
+		description:
+			'Book Tre Stelle Coffee Co. for private events, coffee experiences, and community gatherings in Dallas, TX.',
+		url: 'https://trestellecoffeeco.com/events',
+		type: 'website',
+	},
+};
+
+export default function EventsLayout({ children }: { children: React.ReactNode }) {
+	return children;
+}

--- a/src/app/find-us/layout.tsx
+++ b/src/app/find-us/layout.tsx
@@ -1,0 +1,18 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+	title: 'Find Us',
+	description:
+		'Visit Tre Stelle Coffee Co. — directions, hours, and location details for our Dallas, TX coffee shop.',
+	alternates: { canonical: 'https://trestellecoffeeco.com/find-us' },
+	openGraph: {
+		title: 'Find Us | Tre Stelle Coffee Co.',
+		description: 'Visit Tre Stelle Coffee Co. in Dallas, TX. Directions, hours, and location.',
+		url: 'https://trestellecoffeeco.com/find-us',
+		type: 'website',
+	},
+};
+
+export default function FindUsLayout({ children }: { children: React.ReactNode }) {
+	return children;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,42 +1,67 @@
 import './globals.css';
-// Navbar and Footer are now imported in InnerLayoutClient
-// import Navbar from '../../components/layout/Navbar';
-// import Footer from '../../components/layout/Footer';
-// ClientLayout is now used within InnerLayoutClient
-// import ClientLayout from '../../components/layout/ClientLayout';
-// import SmoothScroller from '../../components/ui/SmoothScroller';
+import type { Metadata } from 'next';
 import BackToTop from '../../components/ui/BackToTop';
 import { CartProvider } from '../context/CartContext';
-// usePathname is no longer needed here
-// import { usePathname } from 'next/navigation';
-import InnerLayoutClient from './InnerLayoutClient'; // Import the new component
+import InnerLayoutClient from './InnerLayoutClient';
+import { SITE_URL, SITE_NAME, SITE_DESCRIPTION, DEFAULT_OG_IMAGE, BUSINESS } from '@/lib/site';
 
-export const metadata = {
-	title: 'Tre Stelle Coffee Co. | Premium Coffee Roastery',
-	description:
-		'Premium coffee roastery bridging modern and traditional coffee craftsmanship since 2019.',
+export const metadata: Metadata = {
+	metadataBase: new URL(SITE_URL),
+	title: {
+		default: `${SITE_NAME} | Premium Coffee Roastery`,
+		template: `%s | ${SITE_NAME}`,
+	},
+	description: SITE_DESCRIPTION,
+	openGraph: {
+		title: `${SITE_NAME} | Premium Coffee Roastery`,
+		description: SITE_DESCRIPTION,
+		type: 'website',
+		url: SITE_URL,
+		siteName: SITE_NAME,
+		images: [{ url: DEFAULT_OG_IMAGE, width: 1200, height: 630, alt: SITE_NAME }],
+	},
+	twitter: {
+		card: 'summary_large_image',
+		title: `${SITE_NAME} | Premium Coffee Roastery`,
+		description: SITE_DESCRIPTION,
+		images: [DEFAULT_OG_IMAGE],
+	},
+	alternates: { canonical: SITE_URL },
+};
+
+const localBusinessJsonLd = {
+	'@context': 'https://schema.org',
+	'@type': 'CafeOrCoffeeShop',
+	name: BUSINESS.name,
+	url: SITE_URL,
+	image: `${SITE_URL}${DEFAULT_OG_IMAGE}`,
+	telephone: BUSINESS.telephone,
+	email: BUSINESS.email,
+	address: {
+		'@type': 'PostalAddress',
+		streetAddress: BUSINESS.streetAddress,
+		addressLocality: BUSINESS.addressLocality,
+		addressRegion: BUSINESS.addressRegion,
+		postalCode: BUSINESS.postalCode,
+		addressCountry: BUSINESS.addressCountry,
+	},
+	priceRange: '$',
+	sameAs: BUSINESS.sameAs,
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
-	// const pathname = usePathname(); // Removed
-	// const isStudioPage = pathname.startsWith('/studio'); // Removed
-
 	return (
 		<html lang="en">
 			<body
 				suppressHydrationWarning={true}
 				className="flex flex-col min-h-screen bg-soft-white text-dark-text"
 			>
+				<script
+					type="application/ld+json"
+					dangerouslySetInnerHTML={{ __html: JSON.stringify(localBusinessJsonLd) }}
+				/>
 				<CartProvider>
-					<InnerLayoutClient>{children}</InnerLayoutClient> {/* Use the new component here */}
-					{/* Navbar, ClientLayout, and Footer are now inside InnerLayoutClient */}
-					{/* {!isStudioPage && <Navbar />} // Removed */}
-					{/* <ClientLayout> // Removed */}
-					{/*   <div className="flex-grow"> // Removed */}
-					{/*     {children} // Removed - children are passed to InnerLayoutClient */}
-					{/*   </div> // Removed */}
-					{/* </ClientLayout> // Removed */}
-					{/* {!isStudioPage && <Footer />} // Removed */}
+					<InnerLayoutClient>{children}</InnerLayoutClient>
 					<BackToTop />
 				</CartProvider>
 			</body>

--- a/src/app/press/layout.tsx
+++ b/src/app/press/layout.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+	title: 'Press & Media',
+	description:
+		'See where Tre Stelle Coffee Co. has been featured — press coverage, awards, and recognition from local and national outlets.',
+	alternates: { canonical: 'https://trestellecoffeeco.com/press' },
+	openGraph: {
+		title: 'Press & Media | Tre Stelle Coffee Co.',
+		description:
+			'See where Tre Stelle Coffee Co. has been featured — press coverage, awards, and recognition.',
+		url: 'https://trestellecoffeeco.com/press',
+		type: 'website',
+	},
+};
+
+export default function PressLayout({ children }: { children: React.ReactNode }) {
+	return children;
+}

--- a/src/app/press/page.tsx
+++ b/src/app/press/page.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react';
 import FadeIn from '../../../components/ui/FadeIn';
 import ScrollReveal from '../../../components/ui/ScrollReveal';
 import Link from 'next/link';
-import { client } from '../../sanity/lib/client'; // Corrected path
+import { readClient as client } from '../../sanity/lib/client'; // Read-only CDN-cached client
 import imageUrlBuilder from '@sanity/image-url';
 import { PortableText } from '@portabletext/react';
 import type { SanityDocument, Image as SanityImageType, PortableTextBlock } from 'sanity'; // Added PortableTextBlock

--- a/src/app/privacy-policy/layout.tsx
+++ b/src/app/privacy-policy/layout.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+	title: 'Privacy Policy',
+	description: 'How Tre Stelle Coffee Co. collects, uses, and protects your personal data.',
+	alternates: { canonical: 'https://trestellecoffeeco.com/privacy-policy' },
+};
+
+export default function PrivacyLayout({ children }: { children: React.ReactNode }) {
+	return children;
+}

--- a/src/app/products/[slug]/page.tsx
+++ b/src/app/products/[slug]/page.tsx
@@ -1,5 +1,7 @@
 import { type SanityDocument } from 'next-sanity';
-import { client } from '@/sanity/lib/client';
+import { readClient as client } from '@/sanity/lib/client';
+import { urlFor } from '@/sanity/lib/image';
+import { SITE_URL } from '@/lib/site';
 import type { Image as SanityImageType } from 'sanity';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
@@ -87,9 +89,29 @@ export async function generateMetadata({
 	if (!product) {
 		return { title: 'Product Not Found' };
 	}
+	const priceLabel = product.price ? `$${product.price.toFixed(2)}` : '';
+	const description = `${product.name} from Tre Stelle Coffee Co.${priceLabel ? ` ${priceLabel}.` : ''} Premium specialty coffee roasted in Dallas, TX.`;
+	const imageUrl = product.images?.[0]
+		? urlFor(product.images[0]).width(1200).height(630).fit('crop').url()
+		: undefined;
+	const canonical = `${SITE_URL}/products/${slug}`;
 	return {
 		title: `${product.name} | Tre Stelle Coffee`,
-		description: `Details about ${product.name}. Price: $${product.price ? product.price.toFixed(2) : 'N/A'}.`,
+		description,
+		alternates: { canonical },
+		openGraph: {
+			title: `${product.name} | Tre Stelle Coffee`,
+			description,
+			type: 'website',
+			url: canonical,
+			images: imageUrl ? [{ url: imageUrl, width: 1200, height: 630, alt: product.name }] : undefined,
+		},
+		twitter: {
+			card: 'summary_large_image',
+			title: `${product.name} | Tre Stelle Coffee`,
+			description,
+			images: imageUrl ? [imageUrl] : undefined,
+		},
 	};
 }
 
@@ -127,8 +149,52 @@ export default async function ProductDetailPage({ params: paramsPromise }: Props
 		);
 	}
 
+	const productImage = product.images?.[0]
+		? urlFor(product.images[0]).width(1200).height(1200).fit('crop').url()
+		: undefined;
+	const approvedReviews = product.reviews ?? [];
+	const avgRating = approvedReviews.length
+		? approvedReviews.reduce((sum, r) => sum + (r.rating || 0), 0) / approvedReviews.length
+		: 0;
+	const productJsonLd = {
+		'@context': 'https://schema.org',
+		'@type': 'Product',
+		name: product.name,
+		image: productImage ? [productImage] : undefined,
+		description: `${product.name} from Tre Stelle Coffee Co. Premium specialty coffee roasted in Dallas, TX.`,
+		brand: { '@type': 'Brand', name: 'Tre Stelle Coffee Co.' },
+		offers: {
+			'@type': 'Offer',
+			url: `${SITE_URL}/products/${slug}`,
+			priceCurrency: 'USD',
+			price: product.price ?? 0,
+			availability: product.isOutOfStock
+				? 'https://schema.org/OutOfStock'
+				: 'https://schema.org/InStock',
+		},
+		...(approvedReviews.length > 0 && {
+			aggregateRating: {
+				'@type': 'AggregateRating',
+				ratingValue: avgRating.toFixed(1),
+				reviewCount: approvedReviews.length,
+			},
+			review: approvedReviews.slice(0, 5).map((r) => ({
+				'@type': 'Review',
+				reviewRating: { '@type': 'Rating', ratingValue: r.rating, bestRating: 5 },
+				author: { '@type': 'Person', name: r.authorName },
+				datePublished: r.submittedAt,
+				...(r.title && { name: r.title }),
+				reviewBody: r.comment,
+			})),
+		}),
+	};
+
 	return (
 		<main className="min-h-screen bg-soft-white pt-36 pb-12">
+			<script
+				type="application/ld+json"
+				dangerouslySetInnerHTML={{ __html: JSON.stringify(productJsonLd) }}
+			/>
 			<FadeIn>
 				<div className="container mx-auto px-4">
 					<ProductDisplayClient product={product} />

--- a/src/app/products/page.tsx
+++ b/src/app/products/page.tsx
@@ -8,7 +8,7 @@
 // import productsData from '../../data/products.json'; // Data now from Sanity
 // import { useCart } from '../../context/CartContext'; // Client hook
 import { type SanityDocument } from 'next-sanity'; // For typing Sanity documents
-import { client } from '../../sanity/lib/client'; // Your Sanity client
+import { readClient as client } from '../../sanity/lib/client'; // Read-only CDN-cached client
 // import imageUrlBuilder from '@sanity/image-url'; // For Sanity images
 import type { Image } from 'sanity'; // Sanity image type
 // PortableText can be added later when we render rich text details
@@ -16,6 +16,21 @@ import type { Image } from 'sanity'; // Sanity image type
 import ProductListWithFilter from '../../components/products/ProductListWithFilter';
 import FadeIn from '../../../components/ui/FadeIn';
 import ContactSection from '../../../components/layout/ContactSection';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+	title: 'Shop Premium Coffee & Merchandise',
+	description:
+		'Shop specialty coffee beans, blends, and Tre Stelle Coffee Co. merchandise. Roasted in Dallas, TX — shipped fresh.',
+	alternates: { canonical: 'https://trestellecoffeeco.com/products' },
+	openGraph: {
+		title: 'Shop Premium Coffee & Merchandise | Tre Stelle Coffee Co.',
+		description:
+			'Specialty coffee beans, blends, and merchandise from Tre Stelle Coffee Co. Roasted in Dallas, TX.',
+		url: 'https://trestellecoffeeco.com/products',
+		type: 'website',
+	},
+};
 
 // Define the Sanity Product Type (adjust based on your Sanity schema)
 interface SanityProduct extends SanityDocument {

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,16 @@
+import type { MetadataRoute } from 'next';
+import { SITE_URL } from '@/lib/site';
+
+export default function robots(): MetadataRoute.Robots {
+	return {
+		rules: [
+			{
+				userAgent: '*',
+				allow: '/',
+				disallow: ['/api/', '/studio/', '/cart', '/checkout'],
+			},
+		],
+		sitemap: `${SITE_URL}/sitemap.xml`,
+		host: SITE_URL,
+	};
+}

--- a/src/app/sitemap.xml/route.ts
+++ b/src/app/sitemap.xml/route.ts
@@ -1,0 +1,78 @@
+import { readClient } from '@/sanity/lib/client';
+import { SITE_URL } from '@/lib/site';
+
+export const revalidate = 3600;
+
+type ProductSlug = { slug?: { current?: string }; _updatedAt?: string };
+
+type Entry = {
+	loc: string;
+	lastmod?: string;
+	changefreq?: 'daily' | 'weekly' | 'monthly' | 'yearly';
+	priority?: number;
+};
+
+function escapeXml(value: string): string {
+	return value
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;')
+		.replace(/"/g, '&quot;')
+		.replace(/'/g, '&apos;');
+}
+
+export async function GET() {
+	const now = new Date().toISOString();
+
+	const staticEntries: Entry[] = [
+		{ loc: SITE_URL, lastmod: now, changefreq: 'daily', priority: 1 },
+		{ loc: `${SITE_URL}/about-us`, lastmod: now, changefreq: 'monthly', priority: 0.8 },
+		{ loc: `${SITE_URL}/products`, lastmod: now, changefreq: 'daily', priority: 0.9 },
+		{ loc: `${SITE_URL}/events`, lastmod: now, changefreq: 'weekly', priority: 0.7 },
+		{ loc: `${SITE_URL}/press`, lastmod: now, changefreq: 'monthly', priority: 0.6 },
+		{ loc: `${SITE_URL}/wholesale`, lastmod: now, changefreq: 'monthly', priority: 0.7 },
+		{ loc: `${SITE_URL}/find-us`, lastmod: now, changefreq: 'monthly', priority: 0.8 },
+		{ loc: `${SITE_URL}/catering`, lastmod: now, changefreq: 'monthly', priority: 0.6 },
+		{ loc: `${SITE_URL}/privacy-policy`, lastmod: now, changefreq: 'yearly', priority: 0.3 },
+		{ loc: `${SITE_URL}/terms`, lastmod: now, changefreq: 'yearly', priority: 0.3 },
+	];
+
+	let productEntries: Entry[] = [];
+	try {
+		const products = await readClient.fetch<ProductSlug[]>(
+			`*[_type == "product" && !(_id in path("drafts.**")) && defined(slug.current)]{
+				slug,
+				_updatedAt
+			}`
+		);
+		productEntries = products
+			.filter((p) => p.slug?.current)
+			.map((p) => ({
+				loc: `${SITE_URL}/products/${p.slug!.current}`,
+				lastmod: p._updatedAt || now,
+				changefreq: 'weekly' as const,
+				priority: 0.7,
+			}));
+	} catch (err) {
+		console.warn('sitemap.xml: failed to fetch products from Sanity', err);
+	}
+
+	const entries = [...staticEntries, ...productEntries];
+	const body = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${entries
+	.map(
+		(e) => `	<url>
+		<loc>${escapeXml(e.loc)}</loc>${e.lastmod ? `\n\t\t<lastmod>${e.lastmod}</lastmod>` : ''}${e.changefreq ? `\n\t\t<changefreq>${e.changefreq}</changefreq>` : ''}${typeof e.priority === 'number' ? `\n\t\t<priority>${e.priority.toFixed(1)}</priority>` : ''}
+	</url>`
+	)
+	.join('\n')}
+</urlset>`;
+
+	return new Response(body, {
+		headers: {
+			'Content-Type': 'application/xml; charset=utf-8',
+			'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=86400',
+		},
+	});
+}

--- a/src/app/terms/layout.tsx
+++ b/src/app/terms/layout.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+	title: 'Terms of Service',
+	description: 'The terms and conditions governing your use of trestellecoffeeco.com.',
+	alternates: { canonical: 'https://trestellecoffeeco.com/terms' },
+};
+
+export default function TermsLayout({ children }: { children: React.ReactNode }) {
+	return children;
+}

--- a/src/app/wholesale/layout.tsx
+++ b/src/app/wholesale/layout.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+	title: 'Wholesale Partnerships',
+	description:
+		'Partner with Tre Stelle Coffee Co. — wholesale specialty coffee for cafés, restaurants, and offices in the Dallas-Fort Worth area.',
+	alternates: { canonical: 'https://trestellecoffeeco.com/wholesale' },
+	openGraph: {
+		title: 'Wholesale Partnerships | Tre Stelle Coffee Co.',
+		description:
+			'Partner with Tre Stelle Coffee Co. — wholesale specialty coffee for cafés, restaurants, and offices.',
+		url: 'https://trestellecoffeeco.com/wholesale',
+		type: 'website',
+	},
+};
+
+export default function WholesaleLayout({ children }: { children: React.ReactNode }) {
+	return children;
+}

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -1,0 +1,20 @@
+export const SITE_URL = 'https://trestellecoffeeco.com';
+export const SITE_NAME = 'Tre Stelle Coffee Co.';
+export const SITE_DESCRIPTION =
+	'Premium coffee roastery bridging modern and traditional coffee craftsmanship since 2019.';
+export const DEFAULT_OG_IMAGE = '/images/Tre-Stelle-Co-Coffee-Shop.jpg';
+
+export const BUSINESS = {
+	name: SITE_NAME,
+	streetAddress: '17390 Preston Road, Suite 210',
+	addressLocality: 'Dallas',
+	addressRegion: 'TX',
+	postalCode: '75252',
+	addressCountry: 'US',
+	telephone: '+19723734355',
+	email: 'contact@trestellecoffeeco.com',
+	sameAs: [
+		'https://www.facebook.com/Tre-Stelle-Coffee-Co-101818161638598/',
+		'https://www.instagram.com/trestellecoffee/',
+	],
+};

--- a/src/sanity/lib/client.ts
+++ b/src/sanity/lib/client.ts
@@ -9,3 +9,12 @@ export const client = createClient({
 	useCdn: false, // Changed to false for more direct cache control with Next.js revalidation
 	token: writeToken, // Only set this for server-side usage!
 });
+
+// Read-only client without token — enables CDN edge caching for public reads.
+// Use this for fetching products, press articles, etc. on public pages.
+export const readClient = createClient({
+	projectId,
+	dataset,
+	apiVersion,
+	useCdn: true,
+});


### PR DESCRIPTION
## Summary

This PR bundles two things:

**1. Carry-over security hardening** (commit `2d231ac`) — these were on the branch but missed the merge of PR #7:
- Open-redirect fix: validate `Origin` header against allowlist before using in Stripe redirect URLs
- Move hardcoded Stripe shipping rate IDs to env vars
- `submit-review`: length limits, email validation, productId format check + existence verification, 5s timeout on hCaptcha
- Add `X-Content-Type-Options: nosniff` and `Permissions-Policy` headers globally

**2. SEO, metadata, and checkout UX (commit `39d1954`)**

SEO / metadata:
- Root layout: `metadataBase`, title template, OG, Twitter cards, and `CafeOrCoffeeShop` JSON-LD with address + contact info
- Per-page metadata via route-level `layout.tsx` for about-us, events, press, find-us, wholesale, cart (noindex), checkout (noindex), privacy-policy, terms
- Products list page metadata
- Product detail pages: expanded `generateMetadata` (canonical + OG + Twitter) and Product JSON-LD with aggregate rating + review snippets
- `/sitemap.xml` route handler that pulls product slugs from Sanity (cached 1h)
- `/robots.ts` referencing the sitemap

Performance:
- Add `readClient` (no token, `useCdn: true`) for public reads — products list, product detail, press now hit the Sanity CDN

Checkout UX:
- Cart "Proceed to Checkout" button: animated spinner, "Redirecting you to secure checkout…" helper, and a "Secure checkout powered by Stripe" trust line

## Test plan

- [ ] Verify `npx next build` succeeds in CI (sandbox lacks env vars, but TypeScript + Turbopack compile pass locally)
- [ ] Hit `/sitemap.xml` in production — should return XML with all products
- [ ] Hit `/robots.txt` in production — should return a valid robots file pointing at the sitemap
- [ ] View page source on `/products/[any-slug]` — confirm OG tags + Product JSON-LD present
- [ ] Share a product URL in iMessage/Slack/Facebook — confirm rich preview renders
- [ ] Add an item to cart and click "Proceed to Checkout" — confirm spinner appears
- [ ] Use Google's Rich Results test on a product URL — confirm Product schema is valid
- [ ] Submit `Origin: https://evil.example` to `/api/checkout` — confirm Stripe URLs use canonical domain, not the attacker's

https://claude.ai/code/session_01BziiQ58DFJHRMAdr8exk3M

---
_Generated by [Claude Code](https://claude.ai/code/session_01BziiQ58DFJHRMAdr8exk3M)_