### PR TITLE
feat: event updates and popup removal (postponed)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,126 @@
+# Tre Stelle Coffee Co. — Claude Handoff
+
+## Project Overview
+Next.js 16 (App Router, Turbopack) e-commerce + marketing site for Tre Stelle Coffee Co., a specialty coffee shop in Dallas, TX. Uses Sanity CMS for content, Stripe for checkout, Resend for transactional email, and hCaptcha for bot protection. Deployed on Vercel.
+
+**Stack:** Next.js 16, React 19, TypeScript, Tailwind CSS, Sanity v5, Stripe v18, Resend, hCaptcha, lru-cache
+
+---
+
+## Active Branch
+All current work is on: `claude/fix-security-issues-eDFXd`
+
+**Open PR #10** — "feat: event updates and popup removal (postponed)"
+- Merge this to deploy to production.
+
+---
+
+## What Has Been Done
+
+### Security fixes
+- `src/app/api/admin/fix-order-reference/route.ts` — auth always enforced (was bypassable if env var unset)
+- `src/app/api/send-tracking-email/route.ts` — webhook secret enforced (was commented out)
+- `src/app/api/email-preview/tracking/route.ts` — XSS fix, HTML-escape all query params before interpolation
+- `src/app/api/order-details/route.ts` — rejects unpaid Stripe sessions (was returning order data for any session ID)
+- `src/app/api/checkout/route.ts` — origin allowlist (was open redirect), Stripe rate IDs moved to env vars
+- `src/app/api/submit-review/route.ts` — input length limits, ReDoS-safe email validation (no regex), product existence check, hCaptcha timeout, no internal error leak
+- `next.config.ts` — added `X-Content-Type-Options: nosniff` and `Permissions-Policy` headers
+
+### SEO / metadata
+- `src/lib/site.ts` — shared constants: SITE_URL, SITE_NAME, BUSINESS object
+- `src/app/layout.tsx` — metadataBase, OG, Twitter cards, CafeOrCoffeeShop JSON-LD
+- `src/app/products/[slug]/page.tsx` — generateMetadata with OG image, Product JSON-LD with offers + reviews
+- Per-page layout.tsx metadata added for: about-us, events, press, find-us, wholesale, cart (noindex), checkout (noindex), privacy-policy, terms
+- `src/app/sitemap.xml/route.ts` — dynamic sitemap fetching product slugs from Sanity
+- `src/app/robots.ts` — disallows /api/, /studio/, /cart, /checkout
+
+### Sanity client split
+- `src/sanity/lib/client.ts` — `client` (write token, no CDN) for mutations; `readClient` (no token, CDN-enabled) for all public reads. Attaching a token bypasses Sanity CDN regardless of `useCdn`, hence the split.
+
+### Cart UX
+- `src/app/cart/page.tsx` — "Proceed to Checkout" button has spinner, aria-busy, helper text, and "🔒 Secure checkout powered by Stripe" trust line
+
+### Event status
+- Event postponed — popup and homepage FeaturedEvent are disabled (date gate set to 2099)
+- `src/lib/events.ts` — Eventbrite URL updated to new listing (ready for when event is rescheduled)
+
+---
+
+## Re-enabling the Event (when rescheduled)
+When Jonathan confirms a new date:
+1. Update the date range in `components/ui/ImmersiveCoffeePopup.tsx` (`isImmersiveCoffeeEventEnabled`)
+2. Re-add `<ImmersiveCoffeePopup />` to `src/app/InnerLayoutClient.tsx`
+3. Update event date/time text in `components/ui/FeaturedEvent.tsx`
+4. Update Eventbrite URL in `src/lib/events.ts` if a new listing is created
+5. Optionally add an Upcoming Events card back to `src/app/events/page.tsx`
+
+---
+
+## Pending Security Items (not yet implemented)
+
+1. **Timing-safe secret comparison** — use `crypto.timingSafeEqual` for webhook/admin token checks in:
+   - `src/app/api/send-tracking-email/route.ts`
+   - `src/app/api/admin/fix-order-reference/route.ts`
+
+2. **Stripe webhook idempotency** — prevent duplicate orders if Stripe retries a webhook. Check for existing order by `paymentIntentId` before creating.
+
+3. **Rate limiting on checkout + order-details** — `/api/checkout` and `/api/order-details` have no rate limiting (submit-review does). Add LRUCache limiter same pattern as submit-review.
+
+4. **Dependabot** — 67 npm vulnerabilities (3 critical, 29 high). Run `npm audit fix` or review Dependabot PRs.
+
+---
+
+## Week 2 QoL (not started)
+- Trust signals: SSL badge, return policy blurb in footer
+- Form autocomplete attributes on checkout/booking forms (`autocomplete="email"` etc.)
+- Empty cart state: show product suggestions instead of blank cart
+- "Notify Me" button for out-of-stock products (collect email, store in Sanity)
+
+## Week 3+ (heavy lift)
+- Compress/re-encode videos: currently ~60MB, target ~25MB (use ffmpeg or Cloudinary)
+- Convert hero PNGs to WebP
+- `loading.tsx` skeleton screens for product pages
+- ISR revalidation on product detail pages (`revalidate = 3600`)
+
+---
+
+## Key File Map
+
+| What | Where |
+|------|-------|
+| Sanity clients (read vs write) | `src/sanity/lib/client.ts` |
+| Shared site constants | `src/lib/site.ts` |
+| Eventbrite URL | `src/lib/events.ts` |
+| Event popup (date gate + modal) | `components/ui/ImmersiveCoffeePopup.tsx` |
+| Homepage featured event section | `components/ui/FeaturedEvent.tsx` |
+| Global layout + JSON-LD | `src/app/layout.tsx` |
+| Inner layout (navbar/footer/popups) | `src/app/InnerLayoutClient.tsx` |
+| Checkout API | `src/app/api/checkout/route.ts` |
+| Stripe webhook | `src/app/api/stripe-webhook/route.ts` |
+| Review submission | `src/app/api/submit-review/route.ts` |
+| Sitemap | `src/app/sitemap.xml/route.ts` |
+| Robots | `src/app/robots.ts` |
+
+---
+
+## Environment Variables Needed (Vercel)
+- `NEXT_PUBLIC_SANITY_PROJECT_ID`
+- `NEXT_PUBLIC_SANITY_DATASET`
+- `SANITY_API_TOKEN` (write token for mutations)
+- `STRIPE_SECRET_KEY`
+- `STRIPE_WEBHOOK_SECRET`
+- `STRIPE_PAID_SHIPPING_RATE_ID` (optional — falls back to hardcoded shr_ ID)
+- `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY`
+- `HCAPTCHA_SECRET`
+- `RESEND_API_KEY`
+- `SANITY_WEBHOOK_SECRET`
+- `ADMIN_SECRET`
+
+---
+
+## Dev Commands
+```bash
+npm run dev       # start dev server (Turbopack)
+npm run build     # production build (requires env vars)
+npx tsc --noEmit  # type check only
+```

--- a/components/ui/ImmersiveCoffeePopup.tsx
+++ b/components/ui/ImmersiveCoffeePopup.tsx
@@ -9,9 +9,9 @@ export function isImmersiveCoffeeEventEnabled(now: Date = new Date()): boolean {
 	if (override === 'true') return true;
 	if (override === 'false') return false;
 
-	// Default behavior: enabled from May 20 through May 31, 2026
-	const start = new Date(2026, 4, 20, 0, 0, 0, 0); // May 20, 2026
-	const end = new Date(2026, 4, 31, 23, 59, 59, 999); // May 31, 2026 end of day
+	// Event postponed — disabled until rescheduled
+	const start = new Date(2099, 0, 1);
+	const end = new Date(2099, 0, 1);
 	return now >= start && now <= end;
 }
 

--- a/src/app/InnerLayoutClient.tsx
+++ b/src/app/InnerLayoutClient.tsx
@@ -7,7 +7,6 @@ import Footer from '../../components/layout/Footer';
 import ClientLayout from '../../components/layout/ClientLayout';
 import FreeShippingBanner from '../../components/ui/FreeShippingBanner';
 import HolidayBoxPopup from '../../components/ui/HolidayBoxPopup';
-import ImmersiveCoffeePopup from '../../components/ui/ImmersiveCoffeePopup';
 
 export default function InnerLayoutClient({ children }: { children: React.ReactNode }) {
 	const pathname = usePathname();
@@ -23,7 +22,6 @@ export default function InnerLayoutClient({ children }: { children: React.ReactN
 			</ClientLayout>
 			{!isStudioPage && <Footer />}
 			{!isStudioPage && <HolidayBoxPopup />}
-			{!isStudioPage && <ImmersiveCoffeePopup />}
 			{/* </SmoothScroller> */}
 		</>
 	);

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -1,2 +1,2 @@
 export const IMMERSIVE_COFFEE_EVENTBRITE_URL =
-	'https://www.eventbrite.com/e/immersive-coffee-experience-tickets-1985402270637?aff=erelexpmlt';
+	'https://www.eventbrite.com/e/immersive-coffee-experience-tickets-1989991125024?aff=oddtdtcreator';


### PR DESCRIPTION
## Summary

- Updated Eventbrite URL to new May 31 listing
- Added Upcoming Events section to `/events` page
- Reactivated homepage FeaturedEvent + entry popup for May 31
- **Removed popup, homepage event section, and events page card** — event postponed by Jonathan
- Date gate set to 2099 so everything can be re-enabled quickly when rescheduled
- Added `CLAUDE.md` handoff doc
- Fixed ReDoS-vulnerable email regex in `/api/submit-review` (CodeQL finding)
- Removed internal `error.message` leak from submit-review catch block

## Test plan
- [ ] Visit site homepage — no event popup, no Featured Event section
- [ ] Visit `/events` — no Upcoming Events card, booking form still works
- [ ] Check CodeQL passes on this PR

https://claude.ai/code/session_01BziiQ58DFJHRMAdr8exk3M

---
_Generated by [Claude Code](https://claude.ai/code/session_01BziiQ58DFJHRMAdr8exk3M)_